### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/include/lsst/pex/policy/Policy.h
+++ b/include/lsst/pex/policy/Policy.h
@@ -30,7 +30,7 @@
 #include <list>
 #include <map>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 
@@ -169,11 +169,11 @@ class ValidationError;
 class Policy : public lsst::daf::base::Citizen, public lsst::daf::base::Persistable {
 public:
 
-    typedef boost::shared_ptr<Policy> Ptr;
-    typedef boost::shared_ptr<const Policy> ConstPtr;
-    typedef boost::shared_ptr<Dictionary> DictPtr;
-    typedef boost::shared_ptr<const Dictionary> ConstDictPtr;
-    typedef boost::shared_ptr<PolicyFile> FilePtr;
+    typedef std::shared_ptr<Policy> Ptr;
+    typedef std::shared_ptr<const Policy> ConstPtr;
+    typedef std::shared_ptr<Dictionary> DictPtr;
+    typedef std::shared_ptr<const Dictionary> ConstDictPtr;
+    typedef std::shared_ptr<PolicyFile> FilePtr;
 
     typedef std::vector<bool> BoolArray;
     typedef std::vector<int> IntArray;

--- a/include/lsst/pex/policy/PolicyConfigured.h
+++ b/include/lsst/pex/policy/PolicyConfigured.h
@@ -78,7 +78,7 @@ class PolicyConfigured {
 public: 
     typedef Policy::Ptr PolicyPtr;
     typedef Policy::ConstPtr ConstPolicyPtr;
-    typedef boost::shared_ptr<PolicySource> PolicySourcePtr;
+    typedef std::shared_ptr<PolicySource> PolicySourcePtr;
 
     /**
      * configure this class with a policy.  

--- a/include/lsst/pex/policy/PolicyFile.h
+++ b/include/lsst/pex/policy/PolicyFile.h
@@ -36,7 +36,7 @@
 #ifndef LSST_PEX_POLICY_FILE_H
 #define LSST_PEX_POLICY_FILE_H
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/regex.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>

--- a/include/lsst/pex/policy/PolicyParserFactory.h
+++ b/include/lsst/pex/policy/PolicyParserFactory.h
@@ -37,7 +37,7 @@
 #include "lsst/daf/base/Citizen.h"
 #include "lsst/pex/policy/Policy.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace lsst {
 namespace pex {
@@ -58,7 +58,7 @@ class PolicyParser;
 class PolicyParserFactory {
 public: 
 
-    typedef boost::shared_ptr<PolicyParserFactory> Ptr;
+    typedef std::shared_ptr<PolicyParserFactory> Ptr;
 
     /**
      * create a factory

--- a/include/lsst/pex/policy/PolicyStreamDestination.h
+++ b/include/lsst/pex/policy/PolicyStreamDestination.h
@@ -35,7 +35,7 @@
 #define LSST_PEX_POLICY_STRMDEST_H
 
 #include <ostream>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "lsst/pex/policy/PolicyDestination.h"
 
@@ -49,7 +49,7 @@ namespace policy {
 class PolicyStreamDestination : public PolicyDestination {
 public:
 
-    typedef boost::shared_ptr<std::ostream> StreamPtr;
+    typedef std::shared_ptr<std::ostream> StreamPtr;
 
     /**
      * create the destination

--- a/include/lsst/pex/policy/PolicyString.h
+++ b/include/lsst/pex/policy/PolicyString.h
@@ -31,7 +31,7 @@
 #ifndef LSST_PEX_POLICY_STRING_H
 #define LSST_PEX_POLICY_STRING_H
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/regex.hpp>
 
 #include "lsst/pex/policy/PolicySource.h"

--- a/include/lsst/pex/policy/PolicyStringDestination.h
+++ b/include/lsst/pex/policy/PolicyStringDestination.h
@@ -35,7 +35,7 @@
 #define LSST_PEX_POLICY_STRDEST_H
 
 #include <ostream>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "lsst/pex/policy/PolicyStreamDestination.h"
 

--- a/include/lsst/pex/policy/SupportedFormats.h
+++ b/include/lsst/pex/policy/SupportedFormats.h
@@ -37,7 +37,7 @@
 
 #include "lsst/pex/policy/PolicyParserFactory.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace lsst {
 namespace pex {
@@ -52,7 +52,7 @@ namespace policy {
 class SupportedFormats {
 public: 
 
-    typedef boost::shared_ptr<SupportedFormats> Ptr;
+    typedef std::shared_ptr<SupportedFormats> Ptr;
 
 //    SupportedFormats() : Citizen(typeid(this)), _formats() { }
 

--- a/python/lsst/pex/policy/policyLib.i
+++ b/python/lsst/pex/policy/policyLib.i
@@ -145,27 +145,27 @@ namespace boost { namespace filesystem { } }
     }
 }
 
-%typemap(out) std::vector<boost::shared_ptr<lsst::pex::policy::Policy > > {
+%typemap(out) std::vector<std::shared_ptr<lsst::pex::policy::Policy > > {
     int len = ($1).size();
     $result = PyList_New(len);
     for (int i = 0; i < len; i++) {
-        boost::shared_ptr<lsst::pex::policy::Policy> * smartresult =
-            new boost::shared_ptr<lsst::pex::policy::Policy>(($1)[i]);
+        std::shared_ptr<lsst::pex::policy::Policy> * smartresult =
+            new std::shared_ptr<lsst::pex::policy::Policy>(($1)[i]);
         PyObject * obj = SWIG_NewPointerObj(SWIG_as_voidptr(smartresult),
-            SWIGTYPE_p_boost__shared_ptrT_lsst__pex__policy__Policy_t,
+            SWIGTYPE_p_std__shared_ptrT_lsst__pex__policy__Policy_t,
             SWIG_POINTER_OWN);
         PyList_SetItem($result, i, obj);
     }
 }
 
-%typemap(out) std::vector<boost::shared_ptr<lsst::pex::policy::PolicyFile > > {
+%typemap(out) std::vector<std::shared_ptr<lsst::pex::policy::PolicyFile > > {
     int len = (*(&$1)).size();
     $result = PyList_New(len);
     for (int i = 0; i < len; i++) {
-        boost::shared_ptr<lsst::pex::policy::PolicyFile> * smartresult =
-            new boost::shared_ptr<lsst::pex::policy::PolicyFile>((*(&$1))[i]);
+        std::shared_ptr<lsst::pex::policy::PolicyFile> * smartresult =
+            new std::shared_ptr<lsst::pex::policy::PolicyFile>((*(&$1))[i]);
         PyObject * obj = SWIG_NewPointerObj(SWIG_as_voidptr(smartresult),
-            SWIGTYPE_p_boost__shared_ptrT_lsst__pex__policy__PolicyFile_t,
+            SWIGTYPE_p_std__shared_ptrT_lsst__pex__policy__PolicyFile_t,
             SWIG_POINTER_OWN);
         PyList_SetItem($result, i, obj);
     }
@@ -237,7 +237,7 @@ namespace boost { namespace filesystem { } }
 %declareException(UnsupportedSyntax, SyntaxError, lsst::pex::policy::UnsupportedSyntax)
 %declareException(ValidationError, lsst.pex.exceptions.LogicError, lsst::pex::policy::ValidationError)
 
-%template(vector_Policy_Ptr) std::vector<boost::shared_ptr<lsst::pex::policy::Policy> >;
+%template(vector_Policy_Ptr) std::vector<std::shared_ptr<lsst::pex::policy::Policy> >;
 
 %extend lsst::pex::policy::Policy {
     void _setBool(const std::string& name, bool value) {

--- a/src/Dictionary.cc
+++ b/src/Dictionary.cc
@@ -27,7 +27,6 @@
 #include "lsst/pex/policy/PolicyFile.h"
 // #include "lsst/pex/utils/Trace.h"
 
-#include <boost/scoped_ptr.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
@@ -719,7 +718,7 @@ void Dictionary::check() const {
     for (Policy::StringArray::const_iterator i = names.begin();
          i != names.end(); ++i)
     {
-        boost::scoped_ptr<Definition> def(makeDef(*i));
+        std::unique_ptr<Definition> def(makeDef(*i));
         def->check();
 
         if (hasSubDictionary(*i)) {
@@ -747,7 +746,7 @@ void Dictionary::validate(const Policy& pol, ValidationError *errs) const {
          i != params.end(); ++i) 
     {
         try {
-            boost::scoped_ptr<Definition> def(makeDef(*i));
+            std::unique_ptr<Definition> def(makeDef(*i));
             def->validate(pol, *i, use);
         }
         catch (NameNotFound& e) {
@@ -761,7 +760,7 @@ void Dictionary::validate(const Policy& pol, ValidationError *errs) const {
     for (Policy::StringArray::const_iterator i = dn.begin(); i != dn.end(); ++i) {
         const string& name = *i;
         if (!pol.exists(name)) { // item in dictionary, but not in policy
-            boost::scoped_ptr<Definition> def(makeDef(name));
+            std::unique_ptr<Definition> def(makeDef(name));
             if (name != Dictionary::KW_CHILD_DEF && def->getMinOccurs() > 0)
                 use->addError(getPrefix() + name,
                               ValidationError::MISSING_REQUIRED);

--- a/src/Dictionary.cc
+++ b/src/Dictionary.cc
@@ -27,12 +27,11 @@
 #include "lsst/pex/policy/PolicyFile.h"
 // #include "lsst/pex/utils/Trace.h"
 
-#include <memory>
 #include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
 
-#include <stdexcept>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <set>
 

--- a/src/Dictionary.cc
+++ b/src/Dictionary.cc
@@ -647,7 +647,7 @@ Policy::DictPtr Dictionary::getSubDictionary(const string& name) const {
         (DictionaryError, subname + " is a " + getTypeName(subname) 
          + " instead of a " + Policy::typeName[Policy::POLICY] + ".");
     ConstPtr subpol = getPolicy(subname);
-    Policy::DictPtr result = boost::make_shared<Dictionary>(*subpol);
+    Policy::DictPtr result = std::make_shared<Dictionary>(*subpol);
     result->setPrefix(_prefix + name + ".");
     return result;
 }
@@ -674,7 +674,7 @@ int Dictionary::loadPolicyFiles(const boost::filesystem::path& repository, bool 
                     defin->set(Dictionary::KW_DICT, getFile(*ni));
                 else
                     defin->set(Dictionary::KW_DICT,
-                               boost::make_shared<PolicyFile>(getString(*ni)));
+                               std::make_shared<PolicyFile>(getString(*ni)));
                 
                 toRemove.push_back(*ni);
             }

--- a/src/Dictionary.cc
+++ b/src/Dictionary.cc
@@ -27,7 +27,7 @@
 #include "lsst/pex/policy/PolicyFile.h"
 // #include "lsst/pex/utils/Trace.h"
 
-#include <boost/make_shared.hpp>
+#include <memory>
 #include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
 

--- a/src/Policy.cc
+++ b/src/Policy.cc
@@ -31,7 +31,7 @@
 #include "lsst/pex/policy/parserexceptions.h"
 // #include "lsst/pex/logging/Trace.h"
 
-#include <boost/make_shared.hpp>
+#include <memory>
 #include <boost/filesystem/path.hpp>
 
 #include <stdexcept>

--- a/src/Policy.cc
+++ b/src/Policy.cc
@@ -107,10 +107,10 @@ Policy::Policy(const char *pathOrUrn)
  */
 Policy::FilePtr Policy::createPolicyFile(const string& pathOrUrn, bool strict) {
     if (UrnPolicyFile::looksLikeUrn(pathOrUrn, strict))
-	// return boost::make_shared<PolicyFile>(new UrnPolicyFile(pathOrUrn));
+	// return std::make_shared<PolicyFile>(new UrnPolicyFile(pathOrUrn));
 	return Policy::FilePtr(new UrnPolicyFile(pathOrUrn));
     else
-	// return boost::make_shared<PolicyFile>(new PolicyFile(pathOrUrn));
+	// return std::make_shared<PolicyFile>(new PolicyFile(pathOrUrn));
 	return Policy::FilePtr(new PolicyFile(pathOrUrn));
 }
 
@@ -125,7 +125,7 @@ void extractDefaults(Policy& target, const Dictionary& dict, ValidationError& ve
         def->setDefaultIn(target, &ve);
         // recurse into sub-dictionaries
         if (def->getType() == Policy::POLICY && dict.hasSubDictionary(name)) {
-            Policy::Ptr subp = boost::make_shared<Policy>();
+            Policy::Ptr subp = std::make_shared<Policy>();
             extractDefaults(*subp, *dict.getSubDictionary(name), ve);
             if (subp->nameCount() > 0)
                 target.add(name, subp);
@@ -250,7 +250,7 @@ const Policy::ConstDictPtr Policy::getDictionary() const {
  * validate() \endcode afterwards.
  */
 void Policy::setDictionary(const Dictionary& dict) {
-    _dictionary = boost::make_shared<Dictionary>(dict);
+    _dictionary = std::make_shared<Dictionary>(dict);
 }
 
 /**
@@ -562,7 +562,7 @@ Policy::PolicyPtrArray Policy::getPolicyArray(const string& name) const {
 
 Policy::FilePtr Policy::getFile(const string& name) const {
     FilePtr out = 
-        boost::dynamic_pointer_cast<PolicyFile>(_data->getAsPersistablePtr(name));
+        std::dynamic_pointer_cast<PolicyFile>(_data->getAsPersistablePtr(name));
     if (! out.get()) 
         throw LSST_EXCEPT(TypeError, name, string(typeName[FILE]));
     return out;
@@ -575,7 +575,7 @@ Policy::FilePtrArray Policy::getFileArray(const string& name) const
     vector<Persistable::Ptr>::const_iterator i;
     FilePtr fp;
     for(i = pfa.begin(); i != pfa.end(); ++i) {
-        fp = boost::dynamic_pointer_cast<PolicyFile>(*i);
+        fp = std::dynamic_pointer_cast<PolicyFile>(*i);
         if (! fp.get())
             throw LSST_EXCEPT(TypeError, name, string(typeName[FILE]));
         out.push_back(fp);
@@ -585,11 +585,11 @@ Policy::FilePtrArray Policy::getFileArray(const string& name) const
 }
 
 void Policy::set(const string& name, const FilePtr& value) {
-    _data->set(name, boost::dynamic_pointer_cast<Persistable>(value));
+    _data->set(name, std::dynamic_pointer_cast<Persistable>(value));
 }
 
 void Policy::add(const string& name, const FilePtr& value) {
-    _data->add(name, boost::dynamic_pointer_cast<Persistable>(value));
+    _data->add(name, std::dynamic_pointer_cast<Persistable>(value));
 }
 
 /**
@@ -628,7 +628,7 @@ int Policy::loadPolicyFiles(const fs::path& repository, bool strict) {
 	    // increment even if fail, since we will remove the file record
 	    ++result;
 
-            Ptr policy = boost::make_shared<Policy>();
+            Ptr policy = std::make_shared<Policy>();
             try {
 		fs::path path = (*pfi)->getPath();
 		// if possible, use the policy file's own loading mechanism

--- a/src/Policy.cc
+++ b/src/Policy.cc
@@ -32,7 +32,6 @@
 // #include "lsst/pex/logging/Trace.h"
 
 #include <boost/make_shared.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <boost/filesystem/path.hpp>
 
 #include <stdexcept>
@@ -408,7 +407,7 @@ int Policy::_names(list<string>& names,
 template <class T> void Policy::_validate(const std::string& name, const T& value, int curCount) {
     if (_dictionary) {
         try {
-            boost::scoped_ptr<Definition> def(_dictionary->makeDef(name));
+            std::unique_ptr<Definition> def(_dictionary->makeDef(name));
             def->validateBasic(name, value, curCount);
         } catch(NameNotFound& e) {
             ValidationError ve(LSST_EXCEPT_HERE);

--- a/src/PolicyFile.cc
+++ b/src/PolicyFile.cc
@@ -30,7 +30,6 @@
  */
 #include <fstream>
 
-#include <boost/scoped_ptr.hpp>
 #include <boost/filesystem/convenience.hpp>
 
 #include "lsst/pex/policy/PolicyFile.h"
@@ -64,7 +63,7 @@ using std::ifstream;
 using boost::regex;
 using boost::regex_match;
 using boost::regex_search;
-using boost::scoped_ptr;
+using std::unique_ptr;
 using lsst::pex::policy::paf::PAFParserFactory;
 
 namespace pexExcept = lsst::pex::exceptions;
@@ -228,7 +227,7 @@ void PolicyFile::load(Policy& policy) const {
         pfactory = _formats->getFactory(fmtname);
     }
 
-    scoped_ptr<PolicyParser> parser(pfactory->createParser(policy));
+    std::unique_ptr<PolicyParser> parser(pfactory->createParser(policy));
 
     ifstream fs(_file.string().c_str());
     if (fs.fail()) 

--- a/src/PolicyString.cc
+++ b/src/PolicyString.cc
@@ -27,8 +27,6 @@
 #include <sstream>
 // #include <iosfwd>
 
-#include <boost/scoped_ptr.hpp>
-
 #include "lsst/pex/policy/PolicyString.h"
 #include "lsst/pex/policy/PolicyFile.h"
 #include "lsst/pex/policy/PolicyParser.h"
@@ -47,7 +45,7 @@ using std::ifstream;
 using boost::regex;
 using boost::regex_match;
 using boost::regex_search;
-using boost::scoped_ptr;
+using std::unique_ptr;
 using lsst::pex::policy::paf::PAFParserFactory;
 
 namespace pexExcept = lsst::pex::exceptions;
@@ -142,7 +140,7 @@ void PolicyString::load(Policy& policy) {
         pfactory = _formats->getFactory(fmtname);
     }
 
-    scoped_ptr<PolicyParser> parser(pfactory->createParser(policy));
+    std::unique_ptr<PolicyParser> parser(pfactory->createParser(policy));
 
     std::istringstream is(_data);
     if (is.fail()) {


### PR DESCRIPTION
Makes the following replacements:
- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
