### PR TITLE
DM-8654: Policy::names(bool) ignores its argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ tests/Policy_3
 tests/Policy_4
 tests/testBadPAFWrite
 tests/testDefaults
+tests/testDm8654

--- a/include/lsst/pex/policy/Policy.h
+++ b/include/lsst/pex/policy/Policy.h
@@ -917,7 +917,9 @@ inline int Policy::fileNames(std::list<std::string>& names, bool topLevelOnly,
 }
 
 inline Policy::StringArray Policy::names(bool topLevelOnly) const {
-    return _data->names();
+    StringArray out;
+    _names(out, topLevelOnly, true, 7);
+    return out;
 }
 inline Policy::StringArray Policy::paramNames(bool topLevelOnly) const {
     StringArray out;
@@ -925,7 +927,9 @@ inline Policy::StringArray Policy::paramNames(bool topLevelOnly) const {
     return out;
 }
 inline Policy::StringArray Policy::policyNames(bool topLevelOnly) const {
-    return _data->propertySetNames(topLevelOnly);
+    StringArray out;
+    _names(out, topLevelOnly, true, 1);
+    return out;
 }
 inline Policy::StringArray Policy::fileNames(bool topLevelOnly) const {
     StringArray out;

--- a/src/Dictionary.cc
+++ b/src/Dictionary.cc
@@ -710,7 +710,7 @@ void Dictionary::check() const {
             (DictionaryError, string("expected a single \"") + KW_DEFINITIONS
              + "\" section; found " + std::to_string(defs.size()));
 
-    Policy::StringArray names = defs[0]->names(false);
+    Policy::StringArray names = defs[0]->names(true);
     for (Policy::StringArray::const_iterator i = names.begin();
          i != names.end(); ++i)
     {
@@ -752,7 +752,7 @@ void Dictionary::validate(const Policy& pol, ValidationError *errs) const {
 
     // check definitions of missing elements for required elements
     Policy::ConstPtr defs = getDefinitions();
-    Policy::StringArray dn = defs->names(false);
+    Policy::StringArray dn = defs->names(true);
     for (Policy::StringArray::const_iterator i = dn.begin(); i != dn.end(); ++i) {
         const string& name = *i;
         if (!pol.exists(name)) { // item in dictionary, but not in policy

--- a/tests/testDm8654.cc
+++ b/tests/testDm8654.cc
@@ -1,0 +1,113 @@
+// -*- LSST-C++ -*-
+
+/*
+ * LSST Data Management System
+ * See COPYRIGHT file at the top of the source tree.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program. If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#include <list>
+#include <set>
+#include <string>
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE Dm8654Cpp
+
+#include "boost/test/unit_test.hpp"
+
+#include "lsst/pex/policy/Policy.h"
+
+/*
+ * Regression tests for https://jira.lsstcorp.org/browse/DM-8654
+ *
+ * See testDm8654.py for tests of the Python interface.
+ */
+namespace lsst {
+namespace pex {
+namespace policy {
+
+    /**
+     * Common test data. Must include heirarchical keys.
+     */
+    struct NameFixture {
+        NameFixture() : diversePolicy(), topNames(), fullNames() {
+            diversePolicy.set("answer", 42);
+
+            topNames.emplace("answer");
+
+            diversePolicy.add("array", 2);
+            diversePolicy.add("array", 3);
+            diversePolicy.add("array", 5);
+            diversePolicy.add("array", 8);
+
+            topNames.emplace("array");
+
+            diversePolicy.set("sub.logical", "false");
+            diversePolicy.set("sub.answer", "42");
+            diversePolicy.set("sub.stringlyTyped", "true");
+
+            topNames.emplace("sub");
+            fullNames.insert(topNames.begin(), topNames.end());
+            fullNames.insert({"sub.logical", "sub.answer", "sub.stringlyTyped"});
+        }
+
+        template <class Iterable>
+        std::set<typename Iterable::value_type> setOf(Iterable const & container) {
+            return std::set<typename Iterable::value_type>(std::begin(container), std::end(container));
+        }
+
+        template <class Iterable>
+        std::list<typename Iterable::value_type> listOf(Iterable const & container) {
+            return std::list<typename Iterable::value_type>(std::begin(container), std::end(container));
+        }
+
+        Policy diversePolicy;
+        std::set<std::string> topNames;
+        std::set<std::string> fullNames;
+    };
+
+    /**
+     * Test whether `Policy::names(bool)` and
+     * `Policy::names(list<string>&, bool, bool)` behave identically.
+     */
+    BOOST_FIXTURE_TEST_CASE(namesMatch, NameFixture)
+    {
+        std::list<std::string> defaultNames, trueNames, falseNames;
+        diversePolicy.names(defaultNames);
+        diversePolicy.names(trueNames, true);
+        diversePolicy.names(falseNames, false);
+
+        BOOST_TEST(listOf(diversePolicy.names()) == defaultNames);
+        BOOST_TEST(listOf(diversePolicy.names(true)) == trueNames);
+        BOOST_TEST(listOf(diversePolicy.names(false)) == falseNames);
+    }
+
+    /**
+     * Test whether `Policy::names(bool)` returns heirarchical names if and
+     * only if they are requested.
+     */
+    BOOST_FIXTURE_TEST_CASE(namesExpected, NameFixture)
+    {
+        BOOST_TEST(setOf(diversePolicy.names()) == fullNames);
+        BOOST_TEST(setOf(diversePolicy.names(true)) == topNames);
+        BOOST_TEST(setOf(diversePolicy.names(false)) == fullNames);
+    }
+
+}}} /* namespace lsst::pex::policy */
+

--- a/tests/testDm8654.py
+++ b/tests/testDm8654.py
@@ -1,0 +1,89 @@
+#
+# LSST Data Management System
+# See COPYRIGHT file at the top of the source tree.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+# -*- python -*-
+"""
+Regression tests for https://jira.lsstcorp.org/browse/DM-8654
+
+See testDm8654.cc for tests of the C++ interface.
+
+Run with:
+   python testDm8654.py
+or
+   pytest testDm8654.py
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import unittest
+
+import lsst.utils.tests
+import lsst.pex.policy as pexPolicy
+
+
+class Dm8654TestSuite(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+        self._diversePolicy = pexPolicy.Policy()
+
+        self._diversePolicy.set("answer", 42)
+
+        self._topNames = {"answer"}
+
+        self._diversePolicy.add("array", 2)
+        self._diversePolicy.add("array", 3)
+        self._diversePolicy.add("array", 5)
+        self._diversePolicy.add("array", 8)
+
+        self._topNames.add("array")
+
+        self._diversePolicy.set("sub.logical", "false")
+        self._diversePolicy.set("sub.answer", "42")
+        self._diversePolicy.set("sub.stringlyTyped", "true")
+
+        self._topNames.add("sub")
+        self._fullNames = self._topNames | {"sub.logical", "sub.answer", "sub.stringlyTyped"}
+
+    def tearDown(self):
+        # For some reason Policies don't get garbage collected(at least in Swig)
+        del self._diversePolicy
+
+    def testNamesExpected(self):
+        """Test if `Policy::names(bool)` returns heirarchical names if and
+        only if they are requested.
+        """
+        self.assertEquals(set(self._diversePolicy.names()), self._fullNames)
+        self.assertEquals(set(self._diversePolicy.names(True)), self._topNames)
+        self.assertEquals(set(self._diversePolicy.names(False)), self._fullNames)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
The change is tested against both the C++ and the Python interfaces because it is hidden from the Python side when wrapping with Swig (i.e., the Python unit test will only become relevant after porting to pybind11). Two internal calls to `Policy::names` had to be changed to preserve previous behavior.